### PR TITLE
Add template for pre and br tags.  Per #26

### DIFF
--- a/lexis-nexis.xsl
+++ b/lexis-nexis.xsl
@@ -128,6 +128,10 @@
 		<p><xsl:apply-templates /></p>
 	</xsl:template>
 
+	<xsl:template match="pre|br">
+		<xsl:copy copy-namespaces="no"><xsl:apply-templates /></xsl:copy>
+	</xsl:template>
+
 	<!--Delete locator and heading-->
 	<xsl:template match="locator|heading" />
 


### PR DESCRIPTION
This is a hard punt on dealing with the horribly broken `pre` tags that Lexis-Nexis generates, but preserves the `br` tags that we need.